### PR TITLE
Update URL for installing linter tool for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ resources:
   install_golangci_lint: &install_golangci_lint
     run:
       name: Install golangci-lint
-      command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+      command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
 
   fmtcheck: &fmtcheck
     run:


### PR DESCRIPTION
[Failing build step](https://app.circleci.com/pipelines/github/datadotworld/dwapi-go/17/workflows/f79e6559-5461-4c6c-90e3-ab9ec4905eff/jobs/18)

[Passing build](https://app.circleci.com/pipelines/github/datadotworld/dwapi-go/18/workflows/fe9bd20f-57c4-4aac-bd44-bbc69125263b/jobs/19)

Docs for the linter tool: https://golangci-lint.run/usage/install/#ci-installation